### PR TITLE
fix(cors): allow VO preview via allow_origin_regex + keep localhost

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,15 +44,12 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "TripMate API"
     PROJECT_VERSION: str = "1.0.0" 
     PROJECT_DESCRIPTION: str = "A comprehensive trip management API"
-    BACKEND_CORS_ORIGINS: List[str] = [
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
-        "http://localhost:8080", 
-        "http://127.0.0.1:8080",
-        "http://localhost:3000",
-        "https://preview-tripmate-kzmowbhku12fye9weaev.vusercontent.net",
-        "https://preview-tripmate-kzmnno8q490jq4fop7x1.vusercontent.net"
-    ]
+    # BACKEND_CORS_ORIGINS: List[str] = [
+    #     "http://localhost:3000",
+    #     "http://127.0.0.1:3000",
+    #     "http://localhost:8080", 
+    #     "http://127.0.0.1:8080"
+    # ]
     
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,15 +11,28 @@ app = FastAPI(
     openapi_url=f"/openapi.json"
 )
 
+# # Set all CORS enabled origins
+# if settings.BACKEND_CORS_ORIGINS:
+#     app.add_middleware(
+#         CORSMiddleware,
+#         allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+#         allow_credentials=True,
+#         allow_methods=["*"],
+#         allow_headers=["*"],
+#     )
+
 # Set all CORS enabled origins
-if settings.BACKEND_CORS_ORIGINS:
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=(
+        r"^(http:\/\/localhost(:\d{1,5})?|http:\/\/127\.0\.0\.1(:\d{1,5})?"
+        r"|https:\/\/preview-tripmate-[a-z0-9]+\.vusercontent\.net)$"
+    ),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 # Include all API routes
 app.include_router(api_router)


### PR DESCRIPTION
this change replaces the static CORS origins list with a regex allowing all VO preview subdomains and localhost, so you don’t have to update the list for each new VO build.